### PR TITLE
fix: correct token middleware references in Authens and Post routers

### DIFF
--- a/Server/apis/routers/Authens.router.js
+++ b/Server/apis/routers/Authens.router.js
@@ -22,14 +22,14 @@ router.post("/checktokenAPI", checktokenAPI);
 
 router.post("/register", register);
 router.post("/login", login);
-router.get("/listingUser", validateApiKey, checktoken, listUser);
-router.get("/searchUser/:PhoneNumber", validateApiKey, checktoken, search_User);
-router.put("/updateRole", validateApiKey, checktoken, updateRole);
+router.get("/listingUser", validateApiKey, checkToken, listUser);
+router.get("/searchUser/:PhoneNumber", validateApiKey, checkToken, search_User);
+router.put("/updateRole", validateApiKey, checkToken, updateRole);
 router.put(
   "/blockAccount/:PhoneNumber",
   validateApiKey,
-  checktoken,
+  checkToken,
   BlockAccount
 );
-router.get("/exportUser", validateApiKey, checktoken, exportUser);
+router.get("/exportUser", validateApiKey, checkToken, exportUser);
 module.exports = router;

--- a/Server/apis/routers/Post.router.js
+++ b/Server/apis/routers/Post.router.js
@@ -10,9 +10,9 @@ const {
   updatePost,
 } = require("../controllers/Post.controller");
 
-router.post("/listings", checktoken, postContent);
+router.post("/listings", checkToken, postContent);
 // router.get("/listings/", getContent);
-router.get("/listings/:_id", checktoken, getContentDetail);
+router.get("/listings/:_id", checkToken, getContentDetail);
 router.put("/listings/state/:_id", updateStatePost);
 router.delete("/listings/delete/:_id", deletePost);
 router.put("/listings/update/:_id", updatePost);


### PR DESCRIPTION
This pull request focuses on standardizing the naming convention for middleware functions by replacing all instances of `checktoken` with `checkToken` across multiple API routes. This change improves code readability and adheres to camelCase naming conventions.

### Middleware naming standardization:

* [`Server/apis/routers/Authens.router.js`](diffhunk://#diff-d15326f494ff3dd53bd8a778980ddf54e39d23ef75d1af5ff8983bae5400174bL25-R34): Updated all occurrences of `checktoken` to `checkToken` in routes such as `/listingUser`, `/searchUser/:PhoneNumber`, `/updateRole`, `/blockAccount/:PhoneNumber`, and `/exportUser`.
* [`Server/apis/routers/Post.router.js`](diffhunk://#diff-ecb063ea284e04811b43b7428236655201bb5483dbef2e3b435fa28fb0aef3d1L13-R15): Replaced `checktoken` with `checkToken` in routes like `/listings` and `/listings/:_id`.