### PR TITLE
fix: update script references from server.js to main.js in package.js…

### DIFF
--- a/Server/package.json
+++ b/Server/package.json
@@ -5,9 +5,9 @@
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon server.js",
+    "dev": "nodemon main.js",
     "build": "echo 'skip build'",
-    "start": "node server.js"
+    "start": "node main.js"
   },
   "keywords": [],
   "author": "",

--- a/Server/vercel.json
+++ b/Server/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "server.js",
+      "src": "main.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "server.js"
+      "dest": "main.js"
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the project to use `main.js` as the entry point instead of `server.js`. The changes ensure consistency across scripts and deployment configuration.

### Updates to entry point:

* [`Server/package.json`](diffhunk://#diff-678798cf677bcd1ce276809cfccd33da9ff594b1b0c557180210a4ed2bd27ffaL8-R10): Updated the `dev` and `start` scripts to reference `main.js` instead of `server.js`.
* [`Server/vercel.json`](diffhunk://#diff-934f11f3c90576610e136c4d315b67fcd2dc3e2e28e15ae3c4361a31a5c5609bL5-R12): Updated the `src` and `dest` fields to reference `main.js` instead of `server.js` for deployment configuration.…on and vercel.json